### PR TITLE
Added test building script that uses go test

### DIFF
--- a/.github/workflows/go-cache-testing.yml
+++ b/.github/workflows/go-cache-testing.yml
@@ -1,0 +1,26 @@
+name: Go
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        go-version: [1.15, 1.16, 1.17]
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+
+    - name: Test
+      run: go test -timeout 30s -run $ -v cache

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module cache
+
+go 1.17


### PR DESCRIPTION
the go test uses the inbuilt go test *testing.T framework to run tests.
Configured to run multiple tests at once using regex.
The test will be run using multiple go-versions on this package to test compatability of other projects that run on different go-versions.
There is not much use to running these tests on different OSs' as go directly compiles to machine binary that can run on any platform.